### PR TITLE
Remove unnecessary file namespace prefix check

### DIFF
--- a/includes/ImgTag.php
+++ b/includes/ImgTag.php
@@ -43,9 +43,7 @@ class ImgTag {
 		$filename = trim( $parser->recursiveTagParse( $filename ) );
 
 		// Remove File: prefix if present
-		if ( preg_match( '/^(File|Image):/i', $filename ) ) {
-			$filename = preg_replace( '/^(File|Image):/i', '', $filename );
-		}
+		$filename = preg_replace( '/^(File|Image):/i', '', $filename );
 
 		$title = Title::makeTitleSafe( NS_FILE, $filename );
 		if ( !$title->exists() ) {


### PR DESCRIPTION
This check is unnecessary and makes your code inefficient when it does encounter a prefix.